### PR TITLE
Docfixes

### DIFF
--- a/basic/LoadAWD/Source/Main.hx
+++ b/basic/LoadAWD/Source/Main.hx
@@ -4,7 +4,7 @@
 
  Demonstrates:
 
- How to use the Loader3D object to load an embedded internal 3ds model.
+ How to use the Asset3DLibrary class to load an embedded internal 3ds model.
  How to map an external asset reference inside a file to an internal embedded asset.
  How to extract material data and use it to set custom material properties on a model.
 

--- a/basic/LoadDAE/Source/Main.hx
+++ b/basic/LoadDAE/Source/Main.hx
@@ -4,7 +4,7 @@
 
  Demonstrates:
 
- How to use the Loader3D object to load an embedded internal DAE model.
+ How to use the Asset3DLibrary class to load an embedded internal DAE model.
 
  Code by Greg Caldwell
  greg.caldwell@geepersinteractive.co.uk

--- a/intermediate/LightProbes/Source/Main.hx
+++ b/intermediate/LightProbes/Source/Main.hx
@@ -4,7 +4,7 @@ Light probe usage in Away3D 4.0
 
 Demonstrates:
 
-How to use the Loader3D object to load an embedded internal obj model.
+How to use the Asset3DLibrary class to load an embedded internal obj model.
 How to use LightProbe objects in combination with StaticLightPicker to simulate indirect lighting
 How to use shadow mapping with point lights
 


### PR DESCRIPTION
There were old Loader3D references in the docs; I changed them to reference Asset3DLibrary which is more accurate to what the code does.